### PR TITLE
fix undertaking for crematorium and DBH burn pit

### DIFF
--- a/1.6/Core/Patches/patches.core.xml
+++ b/1.6/Core/Patches/patches.core.xml
@@ -254,10 +254,43 @@
         </value>
       </li>
 
+      <!-- Make a copy of DoBillsCremate and rename it to DoBillsCremateUndertake.
+           This is because some bills are not undertaking (e.g. burn apparel). -->
+      <li Class="ManyJobs.PatchOps.PatchOperationDuplicate">
+        <xpath>Defs/WorkGiverDef[defName = "DoBillsCremate"]</xpath>
+      </li>
       <li Class="PatchOperationReplace">
-        <xpath>Defs/WorkGiverDef[defName = "DoBillsCremate"]/workType</xpath>
+        <xpath>Defs/WorkGiverDef[defName = "DoBillsCremate"][2]/defName</xpath>
+        <value>
+            <defName>DoBillsCremateUndertake</defName>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/WorkGiverDef[defName = "DoBillsCremateUndertake"]/workType</xpath>
         <value>
           <workType>MJobs_Undertaking</workType>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/RecipeDef[defName = "CremateCorpse"]</xpath>
+        <value>
+          <requiredGiverWorkType>MJobs_Undertaking</requiredGiverWorkType>
+        </value>
+      </li>
+
+      <!-- Change label of the work (for prioritizing work) so that the two works are different. -->
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/WorkGiverDef[defName = "DoBillsCremate"]/verb</xpath>
+        <value>
+          <verb>work at</verb>
+        </value>
+      </li>
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/WorkGiverDef[defName = "DoBillsCremate"]/gerund</xpath>
+        <value>
+          <gerund>working at</gerund>
         </value>
       </li>
 

--- a/Mods/dubwise.dubsbadhygiene/Patches/patches.dubwise.dubsbadhygiene.xml
+++ b/Mods/dubwise.dubsbadhygiene/Patches/patches.dubwise.dubsbadhygiene.xml
@@ -86,6 +86,57 @@
 
   <!-- #endregion -->
 
+  <!-- #region MJobs_Undertaking -->
+
+  <Operation Class="ManyJobs.PatchOps.IfWorkTypeIsEnabled">
+    <workType>MJobs_Undertaking</workType>
+    <operations>
+
+      <!-- Make a copy of DoBillsBurnPit and rename it to DoBillsBurnPitUndertake.
+           This is because some bills are not undertaking (e.g. burn apparel). -->
+      <li Class="ManyJobs.PatchOps.PatchOperationDuplicate">
+        <xpath>Defs/WorkGiverDef[defName = "DoBillsBurnPit"]</xpath>
+      </li>
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/WorkGiverDef[defName = "DoBillsBurnPit"][2]/defName</xpath>
+        <value>
+            <defName>DoBillsBurnPitUndertake</defName>
+        </value>
+      </li>
+
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/WorkGiverDef[defName = "DoBillsBurnPitUndertake"]/workType</xpath>
+        <value>
+          <workType>MJobs_Undertaking</workType>
+        </value>
+      </li>
+
+      <li Class="PatchOperationAdd">
+        <xpath>Defs/RecipeDef[defName = "CremateCorpse"]</xpath>
+        <value>
+          <requiredGiverWorkType>MJobs_Undertaking</requiredGiverWorkType>
+        </value>
+      </li>
+
+      <!-- Change label of the work (for prioritizing work) so that the two works are different. -->
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/WorkGiverDef[defName = "DoBillsBurnPitUndertake"]/verb</xpath>
+        <value>
+          <verb>cremate at</verb>
+        </value>
+      </li>
+      <li Class="PatchOperationReplace">
+        <xpath>Defs/WorkGiverDef[defName = "DoBillsBurnPitUndertake"]/gerund</xpath>
+        <value>
+          <gerund>cremating at</gerund>
+        </value>
+      </li>
+
+    </operations>
+  </Operation>
+
+  <!-- #endregion -->
+
   <!-- #region MJobs_Maintaining -->
 
   <Operation Class="ManyJobs.PatchOps.IfWorkTypeIsEnabled">

--- a/Source/Assemblies/PatchOps/PatchOperationDuplicate.cs
+++ b/Source/Assemblies/PatchOps/PatchOperationDuplicate.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Xml;
+using Verse;
+
+// Duplicates the given xpath (should be renamed or similar afterwards).
+namespace ManyJobs.PatchOps
+{
+    public class PatchOperationDuplicate : PatchOperationPathed
+    {
+        protected override bool ApplyWorker(XmlDocument xml)
+        {
+            bool result = false;
+            foreach (object item in xml.SelectNodes(xpath))
+            {
+                XmlNode xmlNode = item as XmlNode;
+                XmlNode parentNode = xmlNode.ParentNode;
+                if( parentNode != null )
+                {
+                    result = true;
+                    parentNode.AppendChild(xmlNode.OwnerDocument.ImportNode(xmlNode, deep: true));
+                }
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
This is actually fairly complicated. Crematorium (and DBH burn pit) can have two kinds of work, similarly to e.g. campfire, those being cremating and burning other things (apparel, etc.). Cremating should be undertaking (so that its setting actually apply and e.g. prevent children from doing the work), but burning cannot be, because RecipeDef of BurnApparel etc. has requiredGiverWorkType requiring hauling. Therefore there need to be actually two WorkGiverDef's, one for each work type, just like there is DoBillsCookCampfire and DoBillsHaulCampfire for campfire.

One more complication is that both those WorkGiverDef's need to differ in verb and gerund fields, otherwise the right-mouse popup apparently somehow ignores one of them if it's the same text, which would prevent cremating and only burning could be prioritized.